### PR TITLE
edit eksctl to create vpc, besu and goq retain and remount on install

### DIFF
--- a/aws/templates/cluster.yml
+++ b/aws/templates/cluster.yml
@@ -7,35 +7,43 @@ metadata:
   region: us-east-2
   version: "1.21"
 
+# It is recommended that you let eksctl deploy a new VPC for your cluster, it will automatically tag the subnets with the appropriate tags. You may use an existing VPC if you wish but take note of the necessary subnet tags: https://github.com/weaveworks/eksctl/blob/main/examples/04-existing-vpc.yaml https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html
 vpc:
-  id: vpc-
+  # id: vpc-
   cidr: "10.0.0.0/16"
-  subnets:
-    public:
-      public-a:
-        id: subnet-
-      public-b:
-        id: subnet-
-      public-c:
-        id: subnet-
-    private:
-      private-a:
-        id: subnet-
-      private-b:
-        id: subnet-
-      private-c:
-        id: subnet-
+  clusterEndpoints:
+    publicAccess: true
+    privateAccess: true
+  # subnets:
+  #   public:
+  #     public-a:
+  #       id: subnet-
+  #     public-b:
+  #       id: subnet-
+  #     public-c:
+  #       id: subnet-
+  #   private:
+  #     private-a:
+  #       id: subnet-
+  #     private-b:
+  #       id: subnet-
+  #     private-c:
+  #       id: subnet-
 
 managedNodeGroups:
   - name: ng-1
     instanceType: m5.xlarge
-    desiredCapacity: 6
+    desiredCapacity: 6 # increase this capacity if you need member/rpc nodes or more validators
     privateNetworking: true
     labels: { role: workers }
-    subnets:
-      - private-a
-      - private-b
-      - private-c
+    # subnets:
+    #   - private-a
+    #   - private-b
+    #   - private-c
+    iam:
+      withAddonPolicies:
+        ebs: true
+        efs: true
 
 cloudWatch:
   clusterLogging:

--- a/dev/helm/charts/besu-node/templates/node-statefulset.yaml
+++ b/dev/helm/charts/besu-node/templates/node-statefulset.yaml
@@ -61,12 +61,27 @@ kind: StorageClass
 metadata:
   name: {{ include "besu-node.fullname" . }}-storage
   namespace: {{ .Release.Namespace }}
-provisioner: kubernetes.io/aws-ebs
+provisioner: ebs.csi.aws.com
 reclaimPolicy: Retain
 allowVolumeExpansion: true
 parameters:
-  type: gp2
+  type: gp3
   fsType: ext4
+# ---
+# apiVersion: storage.k8s.io/v1
+# kind: StorageClass
+# metadata:
+#   name: {{ include "besu-node.fullname" . }}-storage
+#   namespace: {{ .Release.Namespace }}
+# provisioner: efs.csi.aws.com
+# reclaimPolicy: Retain
+# parameters:
+#   provisioningMode: efs-ap
+#   fileSystemId: #your_file_system_id
+#   directoryPerms: "700"
+#   gidRangeStart: "1000" # optional
+#   gidRangeEnd: "2000" # optional
+#   basePath: "/dynamic_provisioning" # optional
 
 {{- else }}
 
@@ -89,6 +104,7 @@ spec:
 
 {{- end }}
 
+{{- if eq .Values.provider "local" }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -102,7 +118,7 @@ spec:
   resources:
     requests:
       storage: "{{ .Values.storage.pvcSizeLimit }}"
-
+{{- end }}
 
 ---
 apiVersion: apps/v1
@@ -134,6 +150,17 @@ spec:
       app.kubernetes.io/name: {{ include "besu-node.fullname" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   serviceName: {{ include "besu-node.fullname" . }}
+  {{- if or (eq .Values.provider "aws") (eq .Values.provider "azure") }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: {{ include "besu-node.fullname" . }}-storage
+      resources:
+        requests:
+          storage: "{{ .Values.storage.pvcSizeLimit }}"
+  {{- end }}
   template:
     metadata:
       labels:
@@ -388,9 +415,11 @@ spec:
       - name: besu-config
         configMap:
           name: {{ include "besu-node.fullname" . }}-besu-config
+      {{- if eq .Values.provider "local"}}
       - name: data
         persistentVolumeClaim:
           claimName: {{ include "besu-node.fullname" . }}-pvc
+      {{- end }}
       {{- if .Values.node.besu.permissions.enabled }}
       - name: permissions-config
         configMap:

--- a/dev/helm/charts/goquorum-node/templates/node-statefulset.yaml
+++ b/dev/helm/charts/goquorum-node/templates/node-statefulset.yaml
@@ -62,11 +62,11 @@ kind: StorageClass
 metadata:
   name: {{ include "goquorum-node.fullname" . }}-storage
   namespace: {{ .Release.Namespace }}
-provisioner: kubernetes.io/aws-ebs
+provisioner: ebs.csi.aws.com
 reclaimPolicy: Retain
 allowVolumeExpansion: true
 parameters:
-  type: gp2
+  type: gp3
   fsType: ext4
 
 {{- else }}
@@ -89,7 +89,7 @@ spec:
     path: "/tmp/{{ include "goquorum-node.fullname" . }}"
 
 {{- end }}
-
+{{- if eq .Values.provider "local" }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -103,7 +103,7 @@ spec:
   resources:
     requests:
       storage: "{{ .Values.storage.pvcSizeLimit }}"
-
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -134,6 +134,17 @@ spec:
       app.kubernetes.io/name: {{ include "goquorum-node.fullname" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
   serviceName: {{ include "goquorum-node.fullname" . }}
+  {{- if or (eq .Values.provider "aws") (eq .Values.provider "azure") }}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: {{ include "goquorum-node.fullname" . }}-storage
+      resources:
+        requests:
+          storage: "{{ .Values.storage.pvcSizeLimit }}"
+  {{- end }}
   template:
     metadata:
       labels:
@@ -372,9 +383,11 @@ spec:
           items:
             - key: static-nodes.json
               path: static-nodes.json
+      {{- if eq .Values.provider "local"}}
       - name: data
         persistentVolumeClaim:
           claimName: {{ include "goquorum-node.fullname" . }}-pvc
+      {{- end }}
       {{- if .Values.nodeFlags.privacy }}
       - name: tessera-keys
         secret:

--- a/dev/helm/values/genesis-besu.yml
+++ b/dev/helm/values/genesis-besu.yml
@@ -5,7 +5,7 @@ rawGenesisConfig:
     config:
       chainId: 1337
       algorithm:
-        consensus: ibft2 # choose from: ibft2 | qbft | clique
+        consensus: qbft # choose from: ibft2 | qbft | clique
         blockperiodseconds: 10
         epochlength: 30000
         requesttimeoutseconds: 20


### PR DESCRIPTION
- Edited eksctl `cluster.yml` to create a new VPC on deployment to have eksctl manage the tags. To use an existing VPC, yaml has been commented out with some comments
- When helm delete is used on AWS or Azure, a subsequent helm install with the same release name should re-use pvc and have access to the previous chain data (supported for besu and goq)
- Updated AWS eksctl deployment README on how to provision the EBS CSI driver 

Signed-off-by: Eric Lin <eric.lin@consensys.net>