### PR TITLE
fix: remove curl install command

### DIFF
--- a/dev/helm/charts/goquorum-node/templates/node-statefulset.yaml
+++ b/dev/helm/charts/goquorum-node/templates/node-statefulset.yaml
@@ -175,7 +175,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.node.goquorum.metrics.pprofport | quote}}
-        prometheus.io/path: "/debug/metrics/prometheus"        
+        prometheus.io/path: "/debug/metrics/prometheus"
     spec:
       serviceAccountName: {{ include "goquorum-node.fullname" . }}-sa
       containers:
@@ -359,7 +359,6 @@ spec:
           - |
             exec
 
-            apk add curl
           {{- if .Values.nodeFlags.privacy }}
             until $(curl --output /dev/null --silent --head --fail http://localhost:9000/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
             echo 'transaction manager is up';

--- a/playground/kubectl/quorum-go/ibft/statefulsets/member1-statefulset.yaml
+++ b/playground/kubectl/quorum-go/ibft/statefulsets/member1-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9545"
-        prometheus.io/path: "/debug/metrics/prometheus"   
+        prometheus.io/path: "/debug/metrics/prometheus"
     spec:
       serviceAccountName: member1-sa
       initContainers:
@@ -68,9 +68,9 @@ spec:
             - -c
           args:
             - |
-              exec 
+              exec
               curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 http://quorum-rpcnode.quorum.svc.cluster.local:8545
-              sleep 30      
+              sleep 30
       containers:
         - name: member1-tessera
           image: quorumengineering/tessera:latest
@@ -92,12 +92,12 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: TESSERA_CONFIG_TYPE
-              value: "-09"              
-  
+              value: "-09"
+
           volumeMounts:
             - name: keys
               mountPath: /config/keys/
-              readOnly: true   
+              readOnly: true
             - name: data
               mountPath: /data
           ports:
@@ -109,13 +109,13 @@ spec:
               protocol: TCP
             - containerPort: 9101
               name: tessera-q2t
-              protocol: TCP                 
+              protocol: TCP
           command:
             - /bin/sh
             - -c
           args:
             - |
-              exec 
+              exec
               mkdir /data/tm/;
               cp /config/keys/tm.* /data/tm/ ;
 
@@ -142,7 +142,7 @@ spec:
                       "sslConfig": {
                         "tls": "OFF"
                       },
-                      "communicationType" : "REST"    
+                      "communicationType" : "REST"
                     },
                                         {
                       "app":"P2P",
@@ -201,15 +201,15 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: QUORUM_NETWORK_ID
-              value: "10"              
+              value: "10"
             - name: QUORUM_CONSENSUS
-              value: istanbul          
+              value: istanbul
             - name: QUORUM_PTM_URL
               value: http://localhost:9101
           volumeMounts:
             - name: keys
               mountPath: /config/keys/
-              readOnly: true   
+              readOnly: true
             - name: static-nodes-file
               mountPath: /config/static-nodes
               readOnly: true
@@ -239,18 +239,17 @@ spec:
               protocol: UDP
             - containerPort: 9545
               name: metrics
-              protocol: TCP                
+              protocol: TCP
           command:
             - /bin/sh
             - -c
           args:
             - |
               exec
-              apk add curl
-              
+
               until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9000/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
               echo transaction manager is up;
- 
+
               mkdir -p /data/dd
               cp /config/static-nodes/static-nodes.json /data/dd/
               cp /config/permissions-nodes/*.json /data/dd/
@@ -276,7 +275,7 @@ spec:
               --unlock 0 \
               --allow-insecure-unlock \
               --metrics --pprof --pprof.addr 0.0.0.0 --pprof.port 9545 \
-              --password /config/keys/password.txt 
+              --password /config/keys/password.txt
 
       volumes:
         - name: keys
@@ -287,13 +286,13 @@ spec:
             name: goquorum-genesis-configmap
             items:
               - key: genesis.json
-                path: genesis.json                 
+                path: genesis.json
         - name: static-nodes-file
           configMap:
             name: quorum-static-nodes-configmap
             items:
               - key: static-nodes.json
-                path: static-nodes.json 
+                path: static-nodes.json
         - name: permissions-nodes-config
           configMap:
             name: quorum-permissions-nodes-configmap
@@ -301,4 +300,4 @@ spec:
           emptyDir:
             sizeLimit: "2Gi"
 
- 
+

--- a/playground/kubectl/quorum-go/ibft/statefulsets/member2-statefulset.yaml
+++ b/playground/kubectl/quorum-go/ibft/statefulsets/member2-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9545"
-        prometheus.io/path: "/debug/metrics/prometheus"   
+        prometheus.io/path: "/debug/metrics/prometheus"
     spec:
       serviceAccountName: member2-sa
       initContainers:
@@ -68,9 +68,9 @@ spec:
             - -c
           args:
             - |
-              exec 
+              exec
               curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 http://quorum-rpcnode.quorum.svc.cluster.local:8545
-              sleep 30      
+              sleep 30
       containers:
         - name: member2-tessera
           image: quorumengineering/tessera:latest
@@ -92,11 +92,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: TESSERA_CONFIG_TYPE
-              value: "-09"              
+              value: "-09"
           volumeMounts:
             - name: keys
               mountPath: /config/keys/
-              readOnly: true   
+              readOnly: true
             - name: data
               mountPath: /data
           ports:
@@ -108,13 +108,13 @@ spec:
               protocol: TCP
             - containerPort: 9101
               name: tessera-q2t
-              protocol: TCP              
+              protocol: TCP
           command:
             - /bin/sh
             - -c
           args:
             - |
-              exec 
+              exec
               mkdir /data/tm/;
               cp /config/keys/tm.* /data/tm/ ;
 
@@ -141,7 +141,7 @@ spec:
                       "sslConfig": {
                         "tls": "OFF"
                       },
-                      "communicationType" : "REST"    
+                      "communicationType" : "REST"
                     },
                     {
                       "app":"P2P",
@@ -200,15 +200,15 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: QUORUM_NETWORK_ID
-              value: "10"              
+              value: "10"
             - name: QUORUM_CONSENSUS
-              value: istanbul                
+              value: istanbul
             - name: QUORUM_PTM_URL
-              value: http://localhost:9101 
+              value: http://localhost:9101
           volumeMounts:
             - name: keys
               mountPath: /config/keys/
-              readOnly: true   
+              readOnly: true
             - name: static-nodes-file
               mountPath: /config/static-nodes
               readOnly: true
@@ -238,18 +238,17 @@ spec:
               protocol: UDP
             - containerPort: 9545
               name: metrics
-              protocol: TCP                
+              protocol: TCP
           command:
             - /bin/sh
             - -c
           args:
             - |
               exec
-              apk add curl
-              
+
               until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9000/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
               echo transaction manager is up;
- 
+
               mkdir -p /data/dd
               cp /config/static-nodes/static-nodes.json /data/dd/
               cp /config/permissions-nodes/*.json /data/dd/
@@ -275,7 +274,7 @@ spec:
               --unlock 0 \
               --allow-insecure-unlock \
               --metrics --pprof --pprof.addr 0.0.0.0 --pprof.port 9545 \
-              --password /config/keys/password.txt 
+              --password /config/keys/password.txt
 
       volumes:
         - name: keys
@@ -286,13 +285,13 @@ spec:
             name: goquorum-genesis-configmap
             items:
               - key: genesis.json
-                path: genesis.json                 
+                path: genesis.json
         - name: static-nodes-file
           configMap:
             name: quorum-static-nodes-configmap
             items:
               - key: static-nodes.json
-                path: static-nodes.json 
+                path: static-nodes.json
         - name: permissions-nodes-config
           configMap:
             name: quorum-permissions-nodes-configmap
@@ -300,4 +299,4 @@ spec:
           emptyDir:
             sizeLimit: "2Gi"
 
- 
+

--- a/playground/kubectl/quorum-go/ibft/statefulsets/member3-statefulset.yaml
+++ b/playground/kubectl/quorum-go/ibft/statefulsets/member3-statefulset.yaml
@@ -57,7 +57,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9545"
-        prometheus.io/path: "/debug/metrics/prometheus"   
+        prometheus.io/path: "/debug/metrics/prometheus"
     spec:
       serviceAccountName: member3-sa
       initContainers:
@@ -68,7 +68,7 @@ spec:
             - -c
           args:
             - |
-              exec 
+              exec
               curl -X GET --connect-timeout 30 --max-time 10 --retry 6 --retry-delay 0 --retry-max-time 300 http://quorum-rpcnode.quorum.svc.cluster.local:8545
               sleep 30
       containers:
@@ -92,11 +92,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: TESSERA_CONFIG_TYPE
-              value: "-09"              
+              value: "-09"
           volumeMounts:
             - name: keys
               mountPath: /config/keys/
-              readOnly: true   
+              readOnly: true
             - name: data
               mountPath: /data
           ports:
@@ -108,13 +108,13 @@ spec:
               protocol: TCP
             - containerPort: 9101
               name: tessera-q2t
-              protocol: TCP                 
+              protocol: TCP
           command:
             - /bin/sh
             - -c
           args:
             - |
-              exec 
+              exec
               mkdir /data/tm/;
               cp /config/keys/tm.* /data/tm/ ;
 
@@ -141,7 +141,7 @@ spec:
                       "sslConfig": {
                         "tls": "OFF"
                       },
-                      "communicationType" : "REST"     
+                      "communicationType" : "REST"
                     },
                     {
                       "app":"P2P",
@@ -200,15 +200,15 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: QUORUM_NETWORK_ID
-              value: "10"              
+              value: "10"
             - name: QUORUM_CONSENSUS
-              value: istanbul                
+              value: istanbul
             - name: QUORUM_PTM_URL
               value: http://localhost:9101
           volumeMounts:
             - name: keys
               mountPath: /config/keys/
-              readOnly: true   
+              readOnly: true
             - name: static-nodes-file
               mountPath: /config/static-nodes
               readOnly: true
@@ -238,18 +238,17 @@ spec:
               protocol: UDP
             - containerPort: 9545
               name: metrics
-              protocol: TCP                
+              protocol: TCP
           command:
             - /bin/sh
             - -c
           args:
             - |
               exec
-              apk add curl
-              
+
               until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:9000/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
               echo transaction manager is up;
- 
+
               mkdir -p /data/dd
               cp /config/static-nodes/static-nodes.json /data/dd/
               cp /config/permissions-nodes/*.json /data/dd/
@@ -286,13 +285,13 @@ spec:
             name: goquorum-genesis-configmap
             items:
               - key: genesis.json
-                path: genesis.json                 
+                path: genesis.json
         - name: static-nodes-file
           configMap:
             name: quorum-static-nodes-configmap
             items:
               - key: static-nodes.json
-                path: static-nodes.json 
+                path: static-nodes.json
         - name: permissions-nodes-config
           configMap:
             name: quorum-permissions-nodes-configmap
@@ -300,4 +299,4 @@ spec:
           emptyDir:
             sizeLimit: "2Gi"
 
- 
+

--- a/prod/helm/charts/goquorum-node/templates/node-statefulset.yaml
+++ b/prod/helm/charts/goquorum-node/templates/node-statefulset.yaml
@@ -122,7 +122,7 @@ spec:
       resources:
         requests:
           storage: "{{ .Values.storage.pvcSizeLimit }}"
-  {{- end }}  
+  {{- end }}
   template:
     metadata:
       labels:
@@ -137,7 +137,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9545"
-        prometheus.io/path: "/debug/metrics/prometheus"        
+        prometheus.io/path: "/debug/metrics/prometheus"
     spec:
 {{- if eq .Values.provider "azure" }}
       serviceAccountName: {{ include "goquorum-node.fullname" . }}-sa
@@ -316,7 +316,6 @@ spec:
           - |
             exec
 
-            apk add curl
           {{- if .Values.nodeFlags.privacy }}
             until $(curl --output /dev/null --silent --head --fail http://localhost:9000/upcheck); do echo 'waiting for transaction manager to start...'; sleep 5; done;
             echo 'transaction manager is up';


### PR DESCRIPTION
Removed `apk add curl` from manifets/charts since curl is already installed in quorum [image](https://github.com/ConsenSys/quorum/blob/6665a93dc7e8bc57e4870a5c1173c3f1df20c2cf/Dockerfile#L12)

Also, running `apk add` without `--update` flag can fail if repos cache inside container is outdated.

P.S. if curl was added to quorum image only for this purpose - checking tessera is up, then alternative would be to use wget from busybox, for example like [here](https://github.com/baptiste-b-pegasys/quorum-examples/blob/9e0b6cda008e946d1eaed90d6936e7f93767a68f/docker-compose-4nodes-mt-qlight.yml#L19).

P.P.S vscode removed all trailing whitespaces, should I force-push so PR would include only meaningful changes?