### PR TITLE
Fix helm tempates

### DIFF
--- a/helm/charts/blockscout/templates/blockscout-statefulset.yaml
+++ b/helm/charts/blockscout/templates/blockscout-statefulset.yaml
@@ -61,12 +61,11 @@ spec:
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: blockscout
-        app.kubernetes.io/component: statefulset
-        app.kubernetes.io/part-of: {{ include "blockscout.fullname" . }}
-        app.kubernetes.io/namespace: {{ .Release.Namespace }}
-        app.kubernetes.io/release: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: helm
+        app: {{ template "blockscout.fullname" . }}
+        release: {{ .Release.Name }}
+        component: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ include "blockscout.fullname" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ include "blockscout.fullname" . }}-sa
       containers:

--- a/helm/charts/goquorum-node/templates/node-service.yaml
+++ b/helm/charts/goquorum-node/templates/node-service.yaml
@@ -15,7 +15,7 @@ metadata:
 spec:
   type: ClusterIP
   selector:
-    app.kubernetes.io/part-of: {{ include "teku.fullname" . }}
+    app.kubernetes.io/part-of: {{ include "goquorum-node.fullname" . }}
     app.kubernetes.io/namespace: {{ .Release.Namespace }}
     app.kubernetes.io/release: {{ .Release.Name }}
   ports:


### PR DESCRIPTION
Fix problems that cannot install goquorum nodes and blockscout due to broken helm templates.

### GoQuorum
```
$ helm install validator-1 ./charts/goquorum-node --namespace quorum --values ./values/validator.yml 
Error: INSTALLATION FAILED: template: goquorum-node/templates/node-service.yaml:18:34: executing "goquorum-node/templates/node-service.yaml" at <include "teku.fullname" .>: error calling include: template: no template "teku.fullname" associated with template "gotpl"
```

### BlockScout
```
$ helm install blockscout ./charts/blockscout --namespace quorum --values ./values/blockscout-goquorum.yml
Error: INSTALLATION FAILED: StatefulSet.apps "blockscout" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app.kubernetes.io/component":"statefulset", "app.kubernetes.io/managed-by":"helm", "app.kubernetes.io/name":"blockscout", "app.kubernetes.io/namespace":"quorum", "app.kubernetes.io/part-of":"blockscout", "app.kubernetes.io/release":"blockscout"}: `selector` does not match template `labels`
```