### PR TITLE
Fix goquorum monitoring servicemonitor matchLabels

### DIFF
--- a/helm/charts/goquorum-node/templates/node-servicemonitor.yaml
+++ b/helm/charts/goquorum-node/templates/node-servicemonitor.yaml
@@ -20,8 +20,9 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "goquorum-node.fullname" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: {{ .Release.Name }}
+      app.kubernetes.io/part-of: {{ include "goquorum-node.fullname" . }}
+      app.kubernetes.io/namespace: {{ .Release.Namespace }}
+      app.kubernetes.io/release: {{ .Release.Name }}
   endpoints:
   - port: metrics
     interval: 15s


### PR DESCRIPTION
I have set up a goquorum prometheus but could not get the metrics for the blockchain node.
The cause was the Label setting in the prometheus operator, so I fixed this.