### PR TITLE
Update besu-node value of ws enabled to true.

### DIFF
--- a/helm/charts/besu-node/values.yaml
+++ b/helm/charts/besu-node/values.yaml
@@ -73,7 +73,7 @@ node:
       corsOrigins: '["all"]'
       authenticationEnabled: false
     ws:
-      enabled: false
+      enabled: true
       host: "0.0.0.0"
       port: 8546
       api: '["DEBUG","ETH", "ADMIN", "WEB3", "IBFT", "NET", "TRACE", "EEA", "PRIV", "QBFT", "PERM", "TXPOOL"]'


### PR DESCRIPTION
Websokcet connection is necessary for Blockscout and any other blockchain service. But, in this helm chart Websocket default value is false. 

This PR related to https://github.com/ConsenSys/quorum-kubernetes/issues/178

Thanks.