### PR TITLE
Update qgt to 0.2.12

### DIFF
--- a/docker/quorum-k8s-hooks/Dockerfile
+++ b/docker/quorum-k8s-hooks/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-ARG QGT_VERSION=0.2.11
+ARG QGT_VERSION=0.2.12
 
 RUN mkdir -p /root/.kube/ && \
     echo "fd97de6b91a121428112c52e5fe04a15" > /etc/machine-id && \

--- a/helm/charts/besu-genesis/values.yaml
+++ b/helm/charts/besu-genesis/values.yaml
@@ -47,5 +47,5 @@ rawGenesisConfig:
 
 image:
   repository: consensys/quorum-k8s-hooks
-  tag: qgt-0.2.11
+  tag: qgt-0.2.12
   pullPolicy: IfNotPresent

--- a/helm/charts/goquorum-genesis/values.yaml
+++ b/helm/charts/goquorum-genesis/values.yaml
@@ -48,5 +48,5 @@ rawGenesisConfig:
 
 image:
   repository: consensys/quorum-k8s-hooks
-  tag: qgt-0.2.11
+  tag: qgt-0.2.12
   pullPolicy: IfNotPresent


### PR DESCRIPTION
`qgt-0.2.11` does not exist in [consensys/quorum-k8s-hooks](https://hub.docker.com/r/consensys/quorum-k8s-hooks/tags) and cannot pull the image.