### PR TITLE
Updated CSI chart location

### DIFF
--- a/azure/scripts/bootstrap.sh
+++ b/azure/scripts/bootstrap.sh
@@ -41,7 +41,7 @@ echo "Provisioning CSI drivers... "
 az aks get-credentials --resource-group "${AKS_RESOURCE_GROUP}" --name "${AKS_CLUSTER_NAME}" --admin
 # Helm charts for KeyVault drivers
 helm repo add stable https://charts.helm.sh/stable
-helm repo add csi-secrets-store-provider-azure https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts
+helm repo add csi-secrets-store-provider-azure https://azure.github.io/secrets-store-csi-driver-provider-azure/charts
 helm repo update
 helm upgrade --install --namespace "$AKS_NAMESPACE" --create-namespace akv-secrets-csi-driver csi-secrets-store-provider-azure/csi-secrets-store-provider-azure
 helm ls --namespace "$AKS_NAMESPACE"


### PR DESCRIPTION
CSI chart's location has moved - as per https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/charts/csi-secrets-store-provider-azure#installation