### PR TITLE
chore: fix secretProviderClass not found errors

### DIFF
--- a/helm/charts/goquorum-node/templates/node-statefulset.yaml
+++ b/helm/charts/goquorum-node/templates/node-statefulset.yaml
@@ -320,7 +320,7 @@ spec:
           driver: secrets-store.csi.k8s.io
           readOnly: true
           volumeAttributes:
-            secretProviderClass: {{ include "goquorum-node.fullname" . }}-azure-secret-provider
+            secretProviderClass: {{ include "goquorum-node.fullname" . }}-{{ .Values.cluster.provider }}-secret-provider
 {{- else }}
       - name: quorum-keys
         secret:


### PR DESCRIPTION
### Steps to Reproduce
Encountered an error with Helm installation when the `cloudNativeServices` option was enabled and the provider is aws. 

```
cluster:
  provider: 'aws'
  cloudNativeServices: true
```

### Error Messages
secretProviderClass not found errors
```{bash}
Warning  FailedMount  4m57s (x72 over 135m)  kubelet  MountVolume.SetUp failed for volume "secrets-store" : rpc error: code = Unknown desc = failed to get secretproviderclass quorum/goquorum-node-validator-1-azure-secret-provider, error: SecretProviderClass.secrets-store.csi.x-k8s.io "goquorum-node-validator-1-azure-secret-provider" not found
```

### Fixed Part
edit secret-provider-class `{{ .Values.cluster.provider }}`