### PR TITLE
fix: update docker k8s hooks

### DIFF
--- a/helm/charts/besu-genesis/values.yaml
+++ b/helm/charts/besu-genesis/values.yaml
@@ -46,5 +46,5 @@ rawGenesisConfig:
 
 image:
   repository: consensys/quorum-k8s-hooks
-  tag: qgt-0.2.15
+  tag: qgt-0.2.12
   pullPolicy: IfNotPresent

--- a/helm/charts/besu-node/values.yaml
+++ b/helm/charts/besu-node/values.yaml
@@ -155,6 +155,6 @@ image:
     pullPolicy: IfNotPresent
   hooks:
     repository: consensys/quorum-k8s-hooks
-    tag: qgt-0.2.15
+    tag: qgt-0.2.12
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
trying to deploy with helm i received the error below.

i looked for `qgt-0.2.15` in the [docker hub](https://hub.docker.com/r/consensys/quorum-k8s-hooks) and i didn't see it there 

i did see `qgt-0.2.12`, and when i made this change the deployment worked

---


<img width="1693" alt="Screenshot 2024-05-09 at 10 41 35 AM" src="https://github.com/Consensys/quorum-kubernetes/assets/9053984/1f4a8067-1c3b-4aad-bf40-e47cd52966f5" width="200">

---

<img width="1010" alt="Screenshot 2024-05-09 at 10 42 34 AM" src="https://github.com/Consensys/quorum-kubernetes/assets/9053984/0f534761-9a3c-4519-aaee-4ccb1da655d3" width="200">







