### PR TITLE
Azure fixes - setting correct client ids

### DIFF
--- a/helm/charts/besu-genesis/templates/genesis-job-init.yaml
+++ b/helm/charts/besu-genesis/templates/genesis-job-init.yaml
@@ -65,7 +65,7 @@ spec:
                   az keyvault secret show --vault-name {{ .Values.azure.keyvaultName }} --name $key | jq -r '.value' > $fpath
                 fi
               }
-              az login --federated-token "$(cat $AZURE_FEDERATED_TOKEN_FILE)" --service-principal -u $AZURE_CLIENT_ID -t $AZURE_TENANT_ID
+              az login --federated-token "$(cat $AZURE_FEDERATED_TOKEN_FILE)" --service-principal -u {{ .Values.azure.identityClientId }} -t {{ .Values.azure.tenantId }}
               az account set --subscription {{ .Values.azure.subscriptionId }}
 
 {{- else if and (eq .Values.cluster.provider "aws") (.Values.cluster.cloudNativeServices) }}

--- a/helm/charts/besu-node/templates/azure-secret-provider-class.yaml
+++ b/helm/charts/besu-node/templates/azure-secret-provider-class.yaml
@@ -9,7 +9,8 @@ spec:
   provider: azure
   parameters:
     usePodIdentity: "false"
-    useVMManagedIdentity: "false"
+    useVMManagedIdentity: "true"
+    userAssignedIdentityID: "{{ .Values.azure.nodePoolIdentityClientId }}"
     keyvaultName: "{{ .Values.azure.keyvaultName }}"
     tenantId: "{{ .Values.azure.tenantId }}"
     cloudName: "AzurePublicCloud"

--- a/helm/charts/besu-node/templates/node-hooks-pre-delete.yaml
+++ b/helm/charts/besu-node/templates/node-hooks-pre-delete.yaml
@@ -61,7 +61,7 @@ spec:
                 fi
               }
 
-              az login --federated-token "$(cat $AZURE_FEDERATED_TOKEN_FILE)" --service-principal -u $AZURE_CLIENT_ID -t $AZURE_TENANT_ID
+              az login --federated-token "$(cat $AZURE_FEDERATED_TOKEN_FILE)" --service-principal -u {{ .Values.azure.identityClientId }} -t {{ .Values.azure.tenantId }}
               az account set --subscription {{ .Values.azure.subscriptionId }}
 
 {{- else if and (eq .Values.cluster.provider "aws") (.Values.cluster.cloudNativeServices) }}

--- a/helm/charts/besu-node/values.yaml
+++ b/helm/charts/besu-node/values.yaml
@@ -22,6 +22,8 @@ azure:
   serviceAccountName: quorum-sa
   # the clientId of the user assigned managed identity created in the template
   identityClientId: azure-clientId
+  # the clientId of the user assigned managed identity in the node pool's resource group
+  nodePoolIdentityClientId: azure-clientId
   keyvaultName: azure-keyvault
   # the tenant ID of the key vault
   tenantId: azure-tenantId

--- a/helm/values/bootnode.yml
+++ b/helm/values/bootnode.yml
@@ -21,6 +21,8 @@ azure:
   serviceAccountName: quorum-sa
   # the clientId of the user assigned managed identity created in the template
   identityClientId: azure-clientId
+  # the clientId of the user assigned managed identity in the node pool's resource group
+  nodePoolIdentityClientId: azure-clientId
   keyvaultName: azure-keyvault
   # the tenant ID of the key vault
   tenantId: azure-tenantId

--- a/helm/values/reader.yml
+++ b/helm/values/reader.yml
@@ -21,6 +21,8 @@ azure:
   serviceAccountName: quorum-sa
   # the clientId of the user assigned managed identity created in the template
   identityClientId: azure-clientId
+  # the clientId of the user assigned managed identity in the node pool's resource group
+  nodePoolIdentityClientId: azure-clientId
   keyvaultName: azure-keyvault
   # the tenant ID of the key vault
   tenantId: azure-tenantId

--- a/helm/values/txnode.yml
+++ b/helm/values/txnode.yml
@@ -21,6 +21,8 @@ azure:
   serviceAccountName: quorum-sa
   # the clientId of the user assigned managed identity created in the template
   identityClientId: azure-clientId
+  # the clientId of the user assigned managed identity in the node pool's resource group
+  nodePoolIdentityClientId: azure-clientId
   keyvaultName: azure-keyvault
   # the tenant ID of the key vault
   tenantId: azure-tenantId

--- a/helm/values/validator.yml
+++ b/helm/values/validator.yml
@@ -21,6 +21,8 @@ azure:
   serviceAccountName: quorum-sa
   # the clientId of the user assigned managed identity created in the template
   identityClientId: azure-clientId
+  # the clientId of the user assigned managed identity in the node pool's resource group
+  nodePoolIdentityClientId: azure-clientId
   keyvaultName: azure-keyvault
   # the tenant ID of the key vault
   tenantId: azure-tenantId


### PR DESCRIPTION
There are a couple of changes in this PR I made to enable a smooth install on azure aks:

- position of `az aks get credentials` seemed wrong in the bootstrap script as its trying to create a manifest before it has the creds
- the `$AZURE_CLIENT_ID` used during `az login` in the pre/post hooks contains the full resource id in azure, not the user managed identity's client id.  Changed to pull it from the values file
- the azure secret provider class needs to use the managed identity from the cluster's node pool