### PR TITLE
Fixes prometheus scraping for besu dashboard in graphana

### DIFF
--- a/helm/charts/besu-node/templates/node-service.yaml
+++ b/helm/charts/besu-node/templates/node-service.yaml
@@ -85,8 +85,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "besu-node.fullname" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-      app.kubernetes.io/component: {{ .Release.Name }}
+      app.kubernetes.io/component: service
   endpoints:
   - port: metrics
     interval: 15s


### PR DESCRIPTION
I noticed the besu dashboard in graphana is not showing data.  The target labels were showing as dropped in prometheus service discovery.

This PR updates the match labels on the service monitors for besu nodes so that the prometheus operator can find them.