### PR TITLE
Fix typos in README.md and values.yaml

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -4,7 +4,7 @@
 ## Background
 The following is meant to guide you through running Besu or GoQuorum clients in Azure AKS (Kubernetes) in both development and production scenarios. As always you are free to customize the charts to suit your requirements. It is highly recommended to familiarize yourself with AKS (or equivalent Kubernetes infrastructure) before running things in production on Kubernetes.
 
-It essentially comprises base infrastructure that is used to build the cluster & other resources in Azure via an [ARM template](./arm/azuredeploy.json). We also make use some Azure native services and features (tha are provisioned via a [script](./scripts/bootstrap.sh)) after the cluster is created. These include:
+It essentially comprises base infrastructure that is used to build the cluster & other resources in Azure via an [ARM template](./arm/azuredeploy.json). We also make use some Azure native services and features (that are provisioned via a [script](./scripts/bootstrap.sh)) after the cluster is created. These include:
 - [AAD pod identities](https://docs.microsoft.com/en-us/azure/aks/use-azure-ad-pod-identity).
 - [Secrets Store CSI drivers](https://docs.microsoft.com/en-us/azure/key-vault/general/key-vault-integrate-kubernetes)
 - Data is stored using dynamic StorageClasses backed by Azure Files. Please note the [Volume Claims](https://docs.microsoft.com/en-us/azure/aks/azure-disks-dynamic-pv) are fixed sizes and can be updated as you grow via a helm update, and will not need reprovisioning of the underlying storage class.

--- a/helm/README.md
+++ b/helm/README.md
@@ -162,7 +162,7 @@ You may optionally deploy our lightweight Quorum Explorer, which is compatible f
 
 **Going into Production**
 
-If you would like to use the Quorum Explorer in a production environment, it is highly recommended to enable OAuth or, at the minimum, local username and password authentication which is natively supported by the Explorer. The `explorerEnvConfig` section of the `explorer-besu.yaml` and `explorer-goquorum.yaml` files contain the variables that you may change. By default `DISABE_AUTH` is set to `true`, which means authentication is disabled. Change this to `false` if you would like to enable authentication. If this is set to `false`, you must also provide at least one authentication OAuth method by filling the variables below (supports all of those listed in the file).
+If you would like to use the Quorum Explorer in a production environment, it is highly recommended to enable OAuth or, at the minimum, local username and password authentication which is natively supported by the Explorer. The `explorerEnvConfig` section of the `explorer-besu.yaml` and `explorer-goquorum.yaml` files contain the variables that you may change. By default `DISABLE_AUTH` is set to `true`, which means authentication is disabled. Change this to `false` if you would like to enable authentication. If this is set to `false`, you must also provide at least one authentication OAuth method by filling the variables below (supports all of those listed in the file).
 
 You may find out more about the variables [here](https://github.com/ConsenSys/quorum-explorer#going-into-production).
 

--- a/helm/charts/besu-node/values.yaml
+++ b/helm/charts/besu-node/values.yaml
@@ -41,7 +41,7 @@ storage:
       type: gp3
       fsType: ext4
 
-# fixes permissions of volumes becuase besu runs as user `besu` and volumes prefer `root`
+# fixes permissions of volumes because besu runs as user `besu` and volumes prefer `root`
 volumePermissionsFix:
   - local
   - aws


### PR DESCRIPTION
- Corrected "make use some" to "make use of some" in the Azure README.md.
- Fixed spelling of "tha" to "that" in the Azure README.md.
- Corrected "DISABE_AUTH" to "DISABLE_AUTH" in the helm README.md.
- Fixed "becuase" to "because" in the values.yaml file.
